### PR TITLE
Support repeated and splat types

### DIFF
--- a/src/gnomish/analyzer.js
+++ b/src/gnomish/analyzer.js
@@ -162,7 +162,7 @@ class Analyzer extends Visitor {
   typeFromNode (node) {
     const base = this.getTypeNamed(node.getName())
     let t = makeType(base, node.getParams().map(p => this.typeFromNode(p)))
-    if (node.isRepeated()) t = t.repeatable()
+    if (node.isRepeatable()) t = t.repeatable()
     if (node.isSplat()) t = t.splat()
     return t
   }

--- a/src/gnomish/analyzer.js
+++ b/src/gnomish/analyzer.js
@@ -161,7 +161,10 @@ class Analyzer extends Visitor {
 
   typeFromNode (node) {
     const base = this.getTypeNamed(node.getName())
-    return makeType(base, node.getParams().map(p => this.typeFromNode(p)))
+    let t = makeType(base, node.getParams().map(p => this.typeFromNode(p)))
+    if (node.isRepeated()) t = t.repeatable()
+    if (node.isSplat()) t = t.splat()
+    return t
   }
 
   getTypeNamed (name) {

--- a/src/gnomish/analyzer.js
+++ b/src/gnomish/analyzer.js
@@ -182,7 +182,6 @@ class Analyzer extends Visitor {
   }
 
   unifyTypes (lhs, rhs) {
-    console.log({lhs, rhs})
     const u = unify(this.symbolTable, [lhs], [rhs])
     if (!u.wasSuccessful()) {
       throw new Error(

--- a/src/gnomish/analyzer.js
+++ b/src/gnomish/analyzer.js
@@ -114,10 +114,7 @@ class Analyzer extends Visitor {
     let defType = node.getDefault() && node.getDefault().getType()
 
     if (annotatedType && defType) {
-      const u = unify(this.symbolTable, annotatedType, defType)
-      if (!u.wasSuccessful()) {
-        throw new Error(`Types "${annotatedType.toString()}" and "${defType.toString()}" do not match`)
-      }
+      const u = this.unifyTypes(annotatedType, defType)
       u.apply(this.symbolTable)
       node.setType(u.getType())
     } else {
@@ -185,7 +182,8 @@ class Analyzer extends Visitor {
   }
 
   unifyTypes (lhs, rhs) {
-    const u = unify(this.symbolTable, lhs, rhs)
+    console.log({lhs, rhs})
+    const u = unify(this.symbolTable, [lhs], [rhs])
     if (!u.wasSuccessful()) {
       throw new Error(
         `Types "${lhs.toString()}" and "${rhs.toString()}" do not match`)

--- a/src/gnomish/ast.js
+++ b/src/gnomish/ast.js
@@ -309,18 +309,21 @@ class VarNode extends SlotNode {
 }
 
 class TypeNode extends Node {
-  constructor ({name, params, optional}) {
+  constructor ({name, params, attr}) {
     super()
     this.name = name
     this.params = params || []
-    this.optional = optional !== null
+    this.splat = attr && attr === '...'
+    this.repeated = attr && attr === '*'
   }
 
   getName () { return this.name }
 
   getParams () { return this.params }
 
-  isOptional () { return this.optional }
+  isSplat () { return this.splat }
+
+  isRepeated () { return this.repeated }
 
   visitBy (visitor) {
     return visitor.visitType(this)

--- a/src/gnomish/ast.js
+++ b/src/gnomish/ast.js
@@ -314,7 +314,7 @@ class TypeNode extends Node {
     this.name = name
     this.params = params || []
     this.splat = attr && attr === '...'
-    this.repeated = attr && attr === '*'
+    this.repeatable = attr && attr === '*'
   }
 
   getName () { return this.name }
@@ -323,7 +323,7 @@ class TypeNode extends Node {
 
   isSplat () { return this.splat }
 
-  isRepeated () { return this.repeated }
+  isRepeatable () { return this.repeatable }
 
   visitBy (visitor) {
     return visitor.visitType(this)

--- a/src/gnomish/gnomish.pegjs
+++ b/src/gnomish/gnomish.pegjs
@@ -132,8 +132,8 @@ complike "comparison operator"
   = $ ( ( '<' / '>' ) opstem? / '=' opstem )
 
 typeexpr "type expression"
-  = name:identifier params:typeparams? optional:'?'?
-    { return new TypeNode({name, params, optional}) }
+  = name:identifier params:typeparams? attr:( '*' / '...' )?
+    { return new TypeNode({name, params, attr}) }
 
 typeparams "type parameters"
   = '(' _ first:typeexpr rest:( _ ',' _ param:typeexpr { return param } )* ')'

--- a/src/gnomish/methodregistry.js
+++ b/src/gnomish/methodregistry.js
@@ -9,22 +9,13 @@ class Signature {
   }
 
   match (symbolTable, receiverType, callArgTypes) {
-    const st = symbolTable.push()
+    const st = symbolTable.push(Symbol('MethodRegistry match'))
+    const u = unify(st, [this.receiverType, ...this.argTypes], [receiverType, ...callArgTypes])
+    if (!u.wasSuccessful()) return null
 
-    const typePairs = [
-      [this.receiverType, receiverType],
-      ...this.argTypes.map((t, i) => [t, callArgTypes[i]])
-    ]
+    u.apply(st)
 
-    for (const [lhs, rhs] of typePairs) {
-      const u = unify(st, lhs, rhs)
-      if (!u.wasSuccessful()) {
-        return null
-      }
-      u.apply(st)
-    }
-
-    const boundRetType = this.retType.resolveRecursively(st)
+    const boundRetType = this.retType.resolveRecursively(st)[0]
 
     return boundRetType === this.retType
       ? this

--- a/src/gnomish/sexpr.js
+++ b/src/gnomish/sexpr.js
@@ -114,7 +114,7 @@ class SexpVisitor extends Visitor {
       this.result += ' '
       this.visit(param)
     }
-    if (node.isRepeated()) this.result += ' *'
+    if (node.isRepeatable()) this.result += ' *'
     if (node.isSplat()) this.result += ' ...'
     this.result += ')'
   }

--- a/src/gnomish/sexpr.js
+++ b/src/gnomish/sexpr.js
@@ -114,7 +114,8 @@ class SexpVisitor extends Visitor {
       this.result += ' '
       this.visit(param)
     }
-    if (node.isOptional()) this.result += '?'
+    if (node.isRepeated()) this.result += ' *'
+    if (node.isSplat()) this.result += ' ...'
     this.result += ')'
   }
 }

--- a/src/gnomish/type.js
+++ b/src/gnomish/type.js
@@ -25,9 +25,13 @@ class Unification {
   }
 }
 
+const REPEATABLE = Symbol('repeatable')
+const SPLAT = Symbol('splat')
+
 class Type {
-  constructor (name) {
+  constructor (name, attr) {
     this.name = name
+    this.attr = attr
   }
 
   getName () { return this.name }
@@ -46,14 +50,19 @@ class Type {
 
   isCompound () { return false }
 
+  isRepeatable () { return this.attr === REPEATABLE }
+
+  isSplat () { return this.attr === SPLAT }
+
   toString () {
     return this.name
   }
 }
 
 class TypeParameter {
-  constructor (name) {
+  constructor (name, attr) {
     this.name = name
+    this.attr = attr
   }
 
   getName () { return this.name }
@@ -85,15 +94,20 @@ class TypeParameter {
 
   isCompound () { return false }
 
+  isRepeatable () { return this.attr === REPEATABLE }
+
+  isSplat () { return this.attr === SPLAT }
+
   toString () {
     return this.name
   }
 }
 
 class CompoundType {
-  constructor (base, params) {
+  constructor (base, params, attr) {
     this.base = base
     this.params = params
+    this.attr = attr
   }
 
   getBase () { return this.base }
@@ -121,6 +135,10 @@ class CompoundType {
 
   isCompound () { return true }
 
+  isRepeatable () { return this.attr === REPEATABLE }
+
+  isSplat () { return this.attr === SPLAT }
+
   toString () {
     return `${this.base.toString()}(${this.params.map(p => p.toString()).join(', ')})`
   }
@@ -129,7 +147,11 @@ class CompoundType {
 function makeType (name, params = []) {
   let base
   if (typeof name === 'string') {
-    base = name.startsWith("'") ? new TypeParameter(name) : new Type(name)
+    let attr = null
+    if (name.endsWith('*')) attr = REPEATABLE
+    if (name.endsWith('...')) attr = SPLAT
+
+    base = name.startsWith("'") ? new TypeParameter(name, attr) : new Type(name, attr)
   } else {
     base = name
   }

--- a/src/gnomish/type.js
+++ b/src/gnomish/type.js
@@ -39,6 +39,19 @@ class Unification {
     this.bindings.push(...other.bindings)
     return this
   }
+
+  toString () {
+    if (this.wasSuccessful()) {
+      let r = 'Unification : '
+      r += this.types.map(t => t.toString()).join(', ')
+      r += ' ['
+      r += this.bindings.map(b => `${b[0]} => ${b[2].toString()}`).join(' ')
+      r += ']'
+      return r
+    } else {
+      return 'Unification [failed]'
+    }
+  }
 }
 
 class Type {

--- a/src/gnomish/type.js
+++ b/src/gnomish/type.js
@@ -391,6 +391,23 @@ function unify (symbolTable, lTypes, rTypes) {
       if (!rType.isRepeatable() || li >= lTypes.length) ri++
     }
 
+    while (li < lTypes.length) {
+      if (lTypes[li].isRepeatable()) li++
+      if (lTypes[li].isSplat()) {
+        result.assimilate(assignParameterList(lTypes[li].getInner(), []))
+        li++
+      }
+      break
+    }
+    while (ri < rTypes.length) {
+      if (rTypes[ri].isRepeatable()) ri++
+      if (rTypes[ri].isSplat()) {
+        result.assimilate(assignParameterList(rTypes[ri].getInner(), []))
+        ri++
+      }
+      break
+    }
+
     console.log('Final tally:\n', {
       li, llen: lTypes.length, ri, rlen: rTypes.length, result: result.toString()
     })

--- a/src/gnomish/type.js
+++ b/src/gnomish/type.js
@@ -341,6 +341,13 @@ function unify (symbolTable, lTypes, rTypes) {
 
     let li = 0
     let ri = 0
+
+    let lSplat = null
+    const lSplatValues = []
+
+    let rSplat = null
+    const rSplatValues = []
+
     const result = Unification.base()
 
     while (li < lTypes.length && ri < rTypes.length) {
@@ -349,21 +356,17 @@ function unify (symbolTable, lTypes, rTypes) {
       console.log('Resolved:\n', {lType: lType.toString(), rType: rType.toString()})
 
       if (lType.isSplat()) {
-        const values = rTypes.slice(ri)
-        const u = assignParameterList(lType, values)
-        result.assimilate(u)
-
-        li++
-        ri = rTypes.length
+        lSplat = lType
+        lSplatValues.push(rType)
+        ri++
+        if (ri >= rTypes.length) li++
         continue
       }
       if (rType.isSplat()) {
-        const values = lTypes.slice(li)
-        const u = assignParameterList(rType, values)
-        result.assimilate(u)
-
-        li = lTypes.length
-        ri++
+        rSplat = rType
+        rSplatValues.push(lType)
+        li++
+        if (li >= lTypes.length) ri++
         continue
       }
 
@@ -412,6 +415,13 @@ function unify (symbolTable, lTypes, rTypes) {
       li, llen: lTypes.length, ri, rlen: rTypes.length, result: result.toString()
     })
     if (li < lTypes.length || ri < rTypes.length) return Unification.unsuccessful()
+
+    if (lSplat) {
+      result.assimilate(assignParameterList(lSplat.getInner(), lSplatValues))
+    }
+    if (rSplat) {
+      result.assimilate(assignParameterList(rSplat.getInner(), rSplatValues))
+    }
 
     return result
   }

--- a/src/gnomish/type.js
+++ b/src/gnomish/type.js
@@ -122,8 +122,11 @@ class CompoundType extends Type {
 
   resolveRecursively (symbolTable) {
     const t = this.resolve(symbolTable)[0]
-    const nParams = this.params.map(p => p.resolveRecursively(symbolTable))
-    const changed = nParams.some((np, i) => np !== this.params[i])
+    const nParams = this.params.reduce((acc, p) => {
+      acc.push(...p.resolveRecursively(symbolTable))
+      return acc
+    }, [])
+    const changed = nParams.length !== this.params.length || nParams.some((np, i) => np !== this.params[i])
     if (!changed && t === this) {
       return [this]
     } else {

--- a/src/gnomish/type.js
+++ b/src/gnomish/type.js
@@ -285,7 +285,6 @@ function makeType (name, params = []) {
 }
 
 function unify (symbolTable, lTypes, rTypes) {
-  console.log('--- beginning unification ---\n', {lTypes: lTypes.map(t => t.toString()), rTypes: rTypes.map(t => t.toString())})
   const st = symbolTable.push()
   const tType = st.at('Type').getValue()
   const tList = st.at('List').getValue()
@@ -353,7 +352,6 @@ function unify (symbolTable, lTypes, rTypes) {
     while (li < lTypes.length && ri < rTypes.length) {
       const lType = resolveInPlace(lTypes, li)
       const rType = resolveInPlace(rTypes, ri)
-      console.log('Resolved:\n', {lType: lType.toString(), rType: rType.toString()})
 
       if (lType.isSplat()) {
         lSplat = lType
@@ -387,7 +385,6 @@ function unify (symbolTable, lTypes, rTypes) {
         return Unification.unsuccessful()
       }
 
-      console.log('Unified single types as:\n', u.toString())
       result.assimilate(u)
 
       if (!lType.isRepeatable() || ri + 1 >= rTypes.length) li++
@@ -411,9 +408,6 @@ function unify (symbolTable, lTypes, rTypes) {
       break
     }
 
-    console.log('Final tally:\n', {
-      li, llen: lTypes.length, ri, rlen: rTypes.length, result: result.toString()
-    })
     if (li < lTypes.length || ri < rTypes.length) return Unification.unsuccessful()
 
     if (lSplat) {

--- a/test/gnomish/analyzer.test.js
+++ b/test/gnomish/analyzer.test.js
@@ -8,7 +8,7 @@ const {MethodRegistry} = require('../../src/gnomish/methodregistry')
 
 describe('Analyzer', function () {
   let st, mr
-  let tInt, tReal, tString, tBool, tBlock, tOption, tType
+  let tInt, tReal, tString, tBool, tBlock, tOption, tList, tType
 
   const GLOBAL = Symbol('global')
 
@@ -19,6 +19,7 @@ describe('Analyzer', function () {
     tBool = makeType('Bool')
     tBlock = makeType('Block')
     tOption = makeType('Option')
+    tList = makeType('List')
     tType = makeType('Type')
 
     st = new SymbolTable(GLOBAL)
@@ -29,6 +30,7 @@ describe('Analyzer', function () {
     st.setStatic('Bool', tType, tBool)
     st.setStatic('Block', tType, tBlock)
     st.setStatic('Option', tType, tOption)
+    st.setStatic('List', tType, tList)
 
     st.setStatic('true', tBool, true)
     st.setStatic('false', tBool, false)

--- a/test/gnomish/analyzer.test.js
+++ b/test/gnomish/analyzer.test.js
@@ -148,6 +148,32 @@ describe('Analyzer', function () {
         assert.equal(blockType.getParams()[0].getName(), "'A")
         assert.strictEqual(blockType.getParams()[1], blockType.getParams()[0])
       })
+
+      it('understands repeated type parameters', function () {
+        const program = parse('{ x: List(Int*) | x }').analyze(st, mr)
+
+        const blockType = program.node.getLastExpr().getType()
+        const retType = blockType.getParams()[0]
+        assert.isTrue(retType.isCompound())
+        assert.strictEqual(retType.getBase(), tList)
+        assert.lengthOf(retType.getParams(), 1)
+        assert.isTrue(retType.getParams()[0].isRepeatable())
+        assert.strictEqual(retType.getParams()[0].getInner(), tInt)
+      })
+
+      it('understands splat type parameters', function () {
+        const program = parse("{ y: Block(Bool, 'Args...) | y }").analyze(st, mr)
+
+        const blockType = program.node.getLastExpr().getType()
+        const retType = blockType.getParams()[0]
+        assert.isTrue(retType.isCompound())
+        assert.strictEqual(retType.getBase(), tBlock)
+        assert.lengthOf(retType.getParams(), 2)
+        assert.strictEqual(retType.getParams()[0], tBool)
+        assert.isTrue(retType.getParams()[1].isSplat())
+        assert.isTrue(retType.getParams()[1].getInner().isParameter())
+        assert.strictEqual(retType.getParams()[1].getInner().getName(), "'Args")
+      })
     })
 
     describe('IfNode', function () {

--- a/test/gnomish/interpreter.test.js
+++ b/test/gnomish/interpreter.test.js
@@ -8,7 +8,7 @@ const {MethodRegistry} = require('../../src/gnomish/methodregistry')
 
 describe('Interpreter', function () {
   let st, mr
-  let tInt, tReal, tString, tBool, tBlock, tOption, tType
+  let tInt, tReal, tString, tBool, tBlock, tOption, tList, tType
 
   const GLOBAL = Symbol('global')
 
@@ -19,6 +19,7 @@ describe('Interpreter', function () {
     tBool = makeType('Bool')
     tBlock = makeType('Block')
     tOption = makeType('Option')
+    tList = makeType('List')
     tType = makeType('Type')
 
     st = new SymbolTable(GLOBAL)
@@ -29,6 +30,7 @@ describe('Interpreter', function () {
     st.setStatic('Bool', tType, tBool)
     st.setStatic('Block', tType, tBlock)
     st.setStatic('Option', tType, tOption)
+    st.setStatic('List', tType, tList)
 
     st.setStatic('true', tBool, true)
     st.setStatic('false', tBool, false)
@@ -85,7 +87,7 @@ describe('Interpreter', function () {
   })
 
   describe('method calls', function () {
-    it('execues a bound callback', function () {
+    it('executes a bound callback', function () {
       mr.register(tInt, '*', [tInt], tInt, ({receiver}, operand) => {
         return receiver * operand
       })

--- a/test/gnomish/literals.test.js
+++ b/test/gnomish/literals.test.js
@@ -127,4 +127,24 @@ describe('Gnomish literals', function () {
       `)
     })
   })
+
+  describe('type annotations', function () {
+    it('supports repeated type parameters', function () {
+      assertSexp("{ x: List('A*) | x }", `
+        (exprlist
+          (block
+            (arg x : (type List (type 'A *)))
+            (exprlist (var x))))
+      `)
+    })
+
+    it('supports splat type parameters', function () {
+      assertSexp("{ y: Block('R, 'Args...) | y }", `
+        (exprlist
+          (block
+            (arg y : (type Block (type 'R) (type 'Args ...)))
+            (exprlist (var y))))
+      `)
+    })
+  })
 })

--- a/test/gnomish/methodregistry.test.js
+++ b/test/gnomish/methodregistry.test.js
@@ -12,6 +12,7 @@ describe('MethodRegistry', function () {
   const tBool = makeType('Bool')
   const tOption = makeType('Option')
   const tBlock = makeType('Block')
+  const tList = makeType('List')
 
   const right = () => {}
   const wrong = () => {}
@@ -23,6 +24,7 @@ describe('MethodRegistry', function () {
 
     const tType = makeType('Type')
     st.setStatic('Type', tType, tType)
+    st.setStatic('List', tType, tList)
 
     registry = new MethodRegistry()
   })

--- a/test/gnomish/types.test.js
+++ b/test/gnomish/types.test.js
@@ -40,7 +40,7 @@ describe('Type', function () {
     })
 
     it('constructs a repeatable type', function () {
-      const p = makeType('Int*')
+      const p = makeType('Int').repeatable()
       assert.isTrue(p.isSimple())
       assert.isFalse(p.isParameter())
       assert.isFalse(p.isCompound())
@@ -50,7 +50,7 @@ describe('Type', function () {
     })
 
     it('constructs a repeatable type parameter', function () {
-      const p = makeType("'A*")
+      const p = makeType("'A").repeatable()
       assert.isFalse(p.isSimple())
       assert.isTrue(p.isParameter())
       assert.isFalse(p.isCompound())
@@ -60,7 +60,7 @@ describe('Type', function () {
     })
 
     it('constructs a splat type parameter', function () {
-      const p = makeType("'As...")
+      const p = makeType("'As").splat()
       assert.isFalse(p.isSimple())
       assert.isTrue(p.isParameter())
       assert.isFalse(p.isCompound())

--- a/test/gnomish/types.test.js
+++ b/test/gnomish/types.test.js
@@ -380,5 +380,55 @@ describe('Type', function () {
         })
       })
     })
+
+    describe('splat types', function () {
+      it('unifies against an empty list', function () {
+        const t0s = [tInt, makeType("'As").splat()]
+        const t1s = [tInt]
+
+        unifyBothWays(t0s, t1s, u => {
+          assert.isTrue(u.wasSuccessful())
+          assert.deepEqual(u.getTypes(), [tInt])
+          assert.lengthOf(u.bindings, 1)
+          assert.strictEqual(u.bindings[0][0], "'As")
+          assert.deepEqual(u.bindings[0][2], [])
+        })
+      })
+
+      it('unifies against a list of types', function () {
+        const t0s = [tBool, makeType("'Args").splat()]
+        const t1s = [tBool, tInt, tString, tReal, tReal]
+
+        unifyBothWays(t0s, t1s, u => {
+          assert.isTrue(u.wasSuccessful())
+          assert.deepEqual(u.getTypes(), [tBool, tInt, tString, tReal, tReal])
+          assert.lengthOf(u.bindings, 1)
+          assert.strictEqual(u.bindings[0][0], "'Args")
+          assert.deepEqual(u.bindings[0][2], [tInt, tString, tReal, tReal])
+        })
+      })
+
+      it('unifies an existing splat binding', function () {
+        st.setStatic("'Args", makeType(tList, [tType]), [tInt, tBool, tBool])
+
+        const t0s = [tBool, makeType("'Args").splat(), tString]
+        const t1s = [tBool, tInt, tBool, tBool, tString]
+
+        unifyBothWays(t0s, t1s, u => {
+          assert.isTrue(u.wasSuccessful())
+          assert.deepEqual(u.getTypes(), [tBool, tInt, tBool, tBool, tString])
+          assert.lengthOf(u.bindings, 0)
+        })
+      })
+
+      it('fails to unify with a conflicting splat binding', function () {
+        st.setStatic("'Args", makeType(tList, [tType]), [tInt, tBool, tBool])
+
+        const t0s = [tBool, makeType("'Args").splat(), tString]
+        const t1s = [tBool, tInt, tReal, tBool, tString]
+
+        unifyBothWays(t0s, t1s, u => assert.isFalse(u.wasSuccessful()))
+      })
+    })
   })
 })

--- a/test/gnomish/types.test.js
+++ b/test/gnomish/types.test.js
@@ -339,5 +339,46 @@ describe('Type', function () {
         assert.isFalse(u.wasSuccessful())
       })
     })
+
+    describe('repeatable types', function () {
+      it('unifies with no matching types', function () {
+        const t0s = [tInt, tBool.repeatable(), tString]
+        const t1s = [tInt, tString]
+
+        unifyBothWays(t0s, t1s, u => {
+          assert.isTrue(u.wasSuccessful())
+          assert.deepEqual(u.getTypes(), [tInt, tString])
+        })
+      })
+
+      it('unifies with multiple matching types', function () {
+        const t0s = [tInt.repeatable()]
+        const t1s = [tInt, tInt, tInt, tInt]
+
+        unifyBothWays(t0s, t1s, u => {
+          assert.isTrue(u.wasSuccessful())
+          assert.deepEqual(u.getTypes(), [tInt, tInt, tInt, tInt])
+        })
+      })
+
+      it('fails to unify with non-matching types', function () {
+        const t0s = [makeType("'A").repeatable()]
+        const t1s = [tInt, tInt, tBool]
+
+        unifyBothWays(t0s, t1s, u => assert.isFalse(u.wasSuccessful()))
+      })
+
+      it('produces a single binding', function () {
+        const t0s = [makeType("'A").repeatable()]
+        const t1s = [tInt, tInt, tInt]
+
+        unifyBothWays(t0s, t1s, u => {
+          assert.isTrue(u.wasSuccessful())
+          assert.deepEqual(u.getTypes(), t1s)
+          assert.lengthOf(u.bindings, 1)
+          assert.deepEqual(u.bindings[0], ["'A", tType, tInt])
+        })
+      })
+    })
   })
 })

--- a/test/gnomish/types.test.js
+++ b/test/gnomish/types.test.js
@@ -24,6 +24,8 @@ describe('Type', function () {
       assert.isTrue(t.isSimple())
       assert.isFalse(t.isParameter())
       assert.isFalse(t.isCompound())
+      assert.isFalse(t.isRepeatable())
+      assert.isFalse(t.isSplat())
       assert.equal(t.toString(), 'Int')
     })
 
@@ -32,7 +34,39 @@ describe('Type', function () {
       assert.isFalse(p.isSimple())
       assert.isTrue(p.isParameter())
       assert.isFalse(p.isCompound())
+      assert.isFalse(p.isRepeatable())
+      assert.isFalse(p.isSplat())
       assert.equal(p.toString(), "'A")
+    })
+
+    it('constructs a repeatable type', function () {
+      const p = makeType('Int*')
+      assert.isTrue(p.isSimple())
+      assert.isFalse(p.isParameter())
+      assert.isFalse(p.isCompound())
+      assert.isTrue(p.isRepeatable())
+      assert.isFalse(p.isSplat())
+      assert.equal(p.toString(), 'Int*')
+    })
+
+    it('constructs a repeatable type parameter', function () {
+      const p = makeType("'A*")
+      assert.isFalse(p.isSimple())
+      assert.isTrue(p.isParameter())
+      assert.isFalse(p.isCompound())
+      assert.isTrue(p.isRepeatable())
+      assert.isFalse(p.isSplat())
+      assert.equal(p.toString(), "'A*")
+    })
+
+    it('constructs a splat type parameter', function () {
+      const p = makeType("'As...")
+      assert.isFalse(p.isSimple())
+      assert.isTrue(p.isParameter())
+      assert.isFalse(p.isCompound())
+      assert.isFalse(p.isRepeatable())
+      assert.isTrue(p.isSplat())
+      assert.equal(p.toString(), "'As...")
     })
 
     it('constructs a compound type', function () {
@@ -40,6 +74,8 @@ describe('Type', function () {
       assert.isFalse(c.isSimple())
       assert.isFalse(c.isParameter())
       assert.isTrue(c.isCompound())
+      assert.isFalse(c.isRepeatable())
+      assert.isFalse(c.isSplat())
       assert.equal(c.toString(), "Block(Int, 'A, Bool)")
     })
   })


### PR DESCRIPTION
Repeated types allow you to match _homogenous_ lists of types, possibly producing a binding containing a single type:

* `Int*` matches `Int, Int, Int`
* `'A*` matches `String, String, String` and produces a binding `'A => Int`

They'll be needed for the List constructor, which has the signature `World#list('A*) : List('A)`.

Splat types allow you to match and re-use _heterogenous_ lists of types, producing a binding that contains _all_ of the types:

* `'Args...` matches `Int, String, Bool` and produces a binding `'Args => [Int, String, Bool]`

This is necessary for Block#evaluate, which has the signature `Block('R, 'Args...)#evaluate('Args...) : 'R`.

Left to do:

- [x] Add splat types to the grammar and AST TypeNodes.
- [x] Construct splat and repeated types from TypeNodes in the Analyzer.