### PR TITLE
Method dispatch priority

### DIFF
--- a/src/gnomish/methodregistry.js
+++ b/src/gnomish/methodregistry.js
@@ -15,7 +15,6 @@ class Signature {
 
     u.apply(st)
 
-
     const boundRetType = this.retType.resolveRecursively(st)[0]
     return new Match(this, u, boundRetType)
   }


### PR DESCRIPTION
Prioritize method signature matching to prefer more exact, specified matches over "looser" signatures with more type parameters.

This lets us "specialize" methods for certain type signatures without causing collisions.

Given methods with signatures:

1. `Option('A)#selector()`
2. `Option(Int)#selector()`

Signature (2) will be chosen for a call on an `Option(Int)`, but signature (1) will be used for calls on `Option(Bool)` or `Option(String)`.