### PR TITLE
Static side effects

### DIFF
--- a/src/gnomish/analyzer.js
+++ b/src/gnomish/analyzer.js
@@ -165,6 +165,13 @@ class Analyzer extends Visitor {
       node.getName(),
       node.getArgs().map(a => a.getType())
     )
+
+    signature.getStaticCallback()({
+      astNode: node,
+      symbolTable: this.symbolTable,
+      methodRegistery: this.methodRegistry
+    })
+
     node.setType(signature.getReturnType())
     node.setCallback(signature.getCallback())
   }

--- a/src/gnomish/analyzer.js
+++ b/src/gnomish/analyzer.js
@@ -1,5 +1,7 @@
 const {Visitor} = require('./visitor')
 const {makeType, unify} = require('./type')
+const {Block} = require('./stdlib/block')
+const {none, Some} = require('./stdlib/option')
 
 // Static analysis phase, to be performed immediately after parsing an AST, but before interpreting it. Responsible for:
 //
@@ -32,6 +34,10 @@ class Analyzer extends Visitor {
     super.visitExprList(node)
     node.setType(node.getLastExpr().getType())
 
+    if (node.getExprs().every(node => node.hasStaticValue())) {
+      node.setStaticValue(node.getLastExpr().getStaticValue())
+    }
+
     if (needsPush) {
       this.symbolTable = this.symbolTable.pop()
     }
@@ -52,6 +58,27 @@ class Analyzer extends Visitor {
     } else {
       const optionType = makeType(this.tOption, [thType.getParams()[0]])
       node.setType(optionType)
+    }
+
+    if (node.getCondition().getBody().hasStaticValue()) {
+      const cond = node.getCondition().getBody().getStaticValue()
+      const hasTh = node.getThen().getBody().hasStaticValue()
+
+      if (node.getElse()) {
+        const hasElse = node.getElse().getBody().hasStaticValue()
+
+        if (cond && hasTh) {
+          node.setStaticValue(node.getThen().getBody().getStaticValue())
+        }
+
+        if (!cond && hasElse) {
+          node.setStaticValue(node.getElse().getBody().getStaticValue())
+        }
+      } else {
+        if (hasTh) {
+          node.setStaticValue(cond ? new Some(node.getThen().getBody().getStaticValue()) : none)
+        }
+      }
     }
   }
 
@@ -103,7 +130,12 @@ class Analyzer extends Visitor {
       ...node.getArgs().map(arg => arg.getType())
     ]))
 
-    node.captureFrames(this.symbolTable.getCaptures())
+    if (this.symbolTable.getCaptures().size > 0) {
+      node.captureFrames(this.symbolTable.getCaptures())
+    } else {
+      const b = new Block(node.getArgs(), node.getBody())
+      node.setStaticValue(b)
+    }
     this.symbolTable = this.symbolTable.pop()
   }
 

--- a/src/gnomish/ast.js
+++ b/src/gnomish/ast.js
@@ -1,7 +1,7 @@
 class Node {
-  constructor (value = null) {
+  constructor (staticValue = null) {
     this.type = null
-    this.value = value
+    this.staticValue = staticValue
   }
 
   setType (type) {
@@ -16,24 +16,24 @@ class Node {
   }
 
   hasStaticValue () {
-    return this.value !== null
+    return this.staticValue !== null
   }
 
   setStaticValue (value) {
-    this.value = value
+    this.staticValue = value
   }
 
   getStaticValue () {
-    if (this.value === null) {
+    if (this.staticValue === null) {
       throw new Error(`${this.constructor.name} has not been assigned a static value`)
     }
-    return this.value
+    return this.staticValue
   }
 }
 
 class SlotNode extends Node {
-  constructor () {
-    super()
+  constructor (value = null) {
+    super(value)
     this.frame = null
     this.slot = null
   }

--- a/src/gnomish/ast.js
+++ b/src/gnomish/ast.js
@@ -1,8 +1,7 @@
-const STATIC = Symbol('static')
-
 class Node {
-  constructor () {
+  constructor (value = null) {
     this.type = null
+    this.value = value
   }
 
   setType (type) {
@@ -17,7 +16,18 @@ class Node {
   }
 
   hasStaticValue () {
-    return false
+    return this.value !== null
+  }
+
+  setStaticValue (value) {
+    this.value = value
+  }
+
+  getStaticValue () {
+    if (this.value === null) {
+      throw new Error(`${this.constructor.name} has not been assigned a static value`)
+    }
+    return this.value
   }
 }
 
@@ -33,11 +43,6 @@ class SlotNode extends Node {
     this.slot = slot
   }
 
-  setStaticValue (value) {
-    this.frame = STATIC
-    this.slot = value
-  }
-
   getFrame () {
     if (this.frame === null) {
       throw new Error(`${this.constructor.name} has not been assigned a frame yet`)
@@ -48,17 +53,6 @@ class SlotNode extends Node {
   getSlot () {
     if (this.slot === null) {
       throw new Error(`${this.constructor.name} has not been assigned a slot index yet`)
-    }
-    return this.slot
-  }
-
-  hasStaticValue () {
-    return this.frame === STATIC
-  }
-
-  getStaticValue () {
-    if (this.frame !== STATIC) {
-      throw new Error(`${this.constructor.name} is not a static value`)
     }
     return this.slot
   }
@@ -240,16 +234,7 @@ class ArgNode extends SlotNode {
 
 class IntNode extends Node {
   constructor ({minus, digits}) {
-    super()
-    this.value = parseInt((minus || '') + digits.join(''), 10)
-  }
-
-  hasStaticValue () {
-    return true
-  }
-
-  getStaticValue () {
-    return this.value
+    super(parseInt((minus || '') + digits.join(''), 10))
   }
 
   visitBy (visitor) {
@@ -259,16 +244,7 @@ class IntNode extends Node {
 
 class RealNode extends Node {
   constructor ({minus, whole, fraction}) {
-    super()
-    this.value = parseFloat((minus || '') + whole.join('') + '.' + fraction.join(''))
-  }
-
-  hasStaticValue () {
-    return true
-  }
-
-  getStaticValue () {
-    return this.value
+    super(parseFloat((minus || '') + whole.join('') + '.' + fraction.join('')))
   }
 
   visitBy (visitor) {
@@ -278,16 +254,7 @@ class RealNode extends Node {
 
 class StringNode extends Node {
   constructor ({chars}) {
-    super()
-    this.value = chars.join('')
-  }
-
-  hasStaticValue () {
-    return true
-  }
-
-  getStaticValue () {
-    return this.value
+    super(chars.join(''))
   }
 
   visitBy (visitor) {

--- a/src/gnomish/interpreter.js
+++ b/src/gnomish/interpreter.js
@@ -9,6 +9,14 @@ class Interpreter extends Visitor {
     this.currentBlock = null
   }
 
+  visit (node) {
+    if (node.hasStaticValue()) {
+      return node.getStaticValue()
+    }
+
+    return super.visit(node)
+  }
+
   setSlot (frame, slot, value) {
     const f = this.stack.get(frame)
     if (f) {
@@ -92,24 +100,8 @@ class Interpreter extends Visitor {
     }, ...args)
   }
 
-  visitInt (node) {
-    return node.getStaticValue()
-  }
-
-  visitReal (node) {
-    return node.getStaticValue()
-  }
-
-  visitString (node) {
-    return node.getStaticValue()
-  }
-
   visitVar (node) {
-    if (node.hasStaticValue()) {
-      return node.getStaticValue()
-    } else {
-      return this.getSlot(node.getFrame(), node.getSlot())
-    }
+    return this.getSlot(node.getFrame(), node.getSlot())
   }
 
   evaluateBlock (block, args) {

--- a/src/gnomish/methodregistry.js
+++ b/src/gnomish/methodregistry.js
@@ -6,6 +6,8 @@ class Signature {
     this.argTypes = argTypes
     this.callback = callback
     this.retType = retType
+
+    this.staticCallback = () => {}
   }
 
   match (symbolTable, receiverType, callArgTypes) {
@@ -23,8 +25,16 @@ class Signature {
     return this.callback
   }
 
+  getStaticCallback () {
+    return this.staticCallback
+  }
+
   getReturnType () {
     return this.retType
+  }
+
+  setStaticCallback (cb) {
+    this.staticCallback = cb
   }
 
   toString () {
@@ -46,6 +56,10 @@ class Match {
 
   getCallback () {
     return this.signature.getCallback()
+  }
+
+  getStaticCallback () {
+    return this.signature.getStaticCallback()
   }
 
   getReturnType () {
@@ -107,6 +121,7 @@ class MethodRegistry {
 
     const addedSignature = new Signature(receiverType, argTypes, callback, retType)
     signatures.push(addedSignature)
+    return addedSignature
   }
 
   lookup (symbolTable, receiverType, selector, argTypes) {

--- a/src/gnomish/methodregistry.js
+++ b/src/gnomish/methodregistry.js
@@ -37,6 +37,23 @@ class Signature {
     this.staticCallback = cb
   }
 
+  markPure () {
+    this.setStaticCallback(({astNode}) => {
+      if (!astNode.getReceiver().hasStaticValue()) return
+      if (!astNode.getArgs().every(argNode => argNode.hasStaticValue())) return
+
+      const args = astNode.getArgs().map(argNode => argNode.getStaticValue())
+      const value = this.getCallback()({
+        receiver: astNode.getReceiver().getStaticValue(),
+        selector: astNode.getName(),
+        interpreter: Symbol('static'),
+        astNode
+      }, ...args)
+      astNode.setStaticValue(value)
+    })
+    return this
+  }
+
   toString () {
     let r = this.receiverType.toString()
     r += '#('

--- a/src/gnomish/sexpr.js
+++ b/src/gnomish/sexpr.js
@@ -92,15 +92,15 @@ class SexpVisitor extends Visitor {
   }
 
   visitInt (node) {
-    this.result += `(${node.value})`
+    this.result += `(${node.getStaticValue()})`
   }
 
   visitReal (node) {
-    this.result += `(${node.value})`
+    this.result += `(${node.getStaticValue()})`
   }
 
   visitString (node) {
-    const escaped = node.value.replace(/[\\"]/g, '\\$&')
+    const escaped = node.getStaticValue().replace(/[\\"]/g, '\\$&')
     this.result += `("${escaped}")`
   }
 

--- a/src/gnomish/stdlib/any.js
+++ b/src/gnomish/stdlib/any.js
@@ -11,13 +11,13 @@ module.exports = {
 
     methodRegistry.register(
       tA, 'getType', [], t.Type,
-      ({receiver, astNode}) => {
-        return astNode.getReceiver().getType()
-      })
+      ({receiver, astNode}) => astNode.getReceiver().getType()
+    ).markPure()
 
     methodRegistry.register(
       tA, '==', [tA], t.Bool,
-      ({receiver}, arg) => receiver === arg)
+      ({receiver}, arg) => receiver === arg
+    ).markPure()
 
     methodRegistry.register(
       tA, 'debug', [], tA,
@@ -25,6 +25,7 @@ module.exports = {
         const type = astNode ? astNode.getReceiver().getType() : '<unknown>'
         console.log(`${util.inspect(receiver, {breakLength: 100})}: ${type}`)
         return receiver
-      })
+      }
+    ).markPure()
   }
 }

--- a/src/gnomish/stdlib/bool.js
+++ b/src/gnomish/stdlib/bool.js
@@ -7,7 +7,14 @@ module.exports = {
     symbolTable.setStatic('true', t.Bool, true)
     symbolTable.setStatic('false', t.Bool, false)
 
-    methodRegistry.register(t.Bool, '&&', [t.Bool], t.Bool, ({receiver}, operand) => receiver && operand)
-    methodRegistry.register(t.Bool, '||', [t.Bool], t.Bool, ({receiver}, operand) => receiver || operand)
+    methodRegistry.register(
+      t.Bool, '&&', [t.Bool], t.Bool,
+      ({receiver}, operand) => receiver && operand
+    ).markPure()
+
+    methodRegistry.register(
+      t.Bool, '||', [t.Bool], t.Bool,
+      ({receiver}, operand) => receiver || operand
+    ).markPure()
   }
 }

--- a/src/gnomish/stdlib/numbers.js
+++ b/src/gnomish/stdlib/numbers.js
@@ -22,11 +22,11 @@ module.exports = {
 
   registerMethods (t, symbolTable, methodRegistry) {
     commonMethods(t, t.Int, methodRegistry)
-    methodRegistry.register(t.Int, 'toReal', [], t.Real, ({receiver}) => receiver)
+    methodRegistry.register(t.Int, 'toReal', [], t.Real, ({receiver}) => receiver).markPure()
 
     commonMethods(t, t.Real, methodRegistry)
-    methodRegistry.register(t.Real, 'round', [], t.Int, ({receiver}) => Math.round(receiver))
-    methodRegistry.register(t.Real, 'floor', [], t.Int, ({receiver}) => Math.floor(receiver))
-    methodRegistry.register(t.Real, 'ceiling', [], t.Int, ({receiver}) => Math.ceil(receiver))
+    methodRegistry.register(t.Real, 'round', [], t.Int, ({receiver}) => Math.round(receiver)).markPure()
+    methodRegistry.register(t.Real, 'floor', [], t.Int, ({receiver}) => Math.floor(receiver)).markPure()
+    methodRegistry.register(t.Real, 'ceiling', [], t.Int, ({receiver}) => Math.ceil(receiver)).markPure()
   }
 }

--- a/src/gnomish/stdlib/option.js
+++ b/src/gnomish/stdlib/option.js
@@ -42,7 +42,7 @@ module.exports = {
 
     methodRegistry.register(t.World, 'some', [tA], tOptionA, (_, value) => {
       return new Some(value)
-    })
+    }).markPure()
 
     symbolTable.setStatic('none', tOptionA, none)
 
@@ -58,7 +58,7 @@ module.exports = {
       } else {
         return true
       }
-    })
+    }).markPure()
 
     // Direct form
     methodRegistry.register(tOptionA, 'or', [tA], tA, ({receiver}, alt) => {
@@ -67,7 +67,7 @@ module.exports = {
       } else {
         return alt
       }
-    })
+    }).markPure()
 
     // Block form
     methodRegistry.register(tOptionA, 'or', [makeType(t.Block, [tA])], tA, ({receiver, interpreter}, blk) => {
@@ -99,7 +99,7 @@ module.exports = {
         if (receiver.hasValue()) result.push(receiver.getValue())
         if (other.hasValue()) result.push(other.getValue())
         return result
-      })
+      }).markPure()
 
     methodRegistry.register(
       tOptionA, '+', [tListA], tListA,

--- a/src/gnomish/stdlib/pair.js
+++ b/src/gnomish/stdlib/pair.js
@@ -24,20 +24,24 @@ module.exports = {
     // Construction
     methodRegistry.register(
       t.World, 'pair', [tA, tB], tPairAB,
-      (_, l, r) => new Pair(l, r))
+      (_, l, r) => new Pair(l, r)
+    ).markPure()
 
     methodRegistry.register(
       tA, '=>', [tB], tPairAB,
-      ({receiver}, r) => new Pair(receiver, r))
+      ({receiver}, r) => new Pair(receiver, r)
+    ).markPure()
 
     // Accessors
 
     methodRegistry.register(
       tPairAB, 'left', [], tA,
-      ({receiver}) => receiver.getLeft())
+      ({receiver}) => receiver.getLeft()
+    ).markPure()
 
     methodRegistry.register(
       tPairAB, 'right', [], tB,
-      ({receiver}) => receiver.getRight())
+      ({receiver}) => receiver.getRight()
+    ).markPure()
   }
 }

--- a/src/gnomish/stdlib/string.js
+++ b/src/gnomish/stdlib/string.js
@@ -6,11 +6,13 @@ module.exports = {
   registerMethods (t, symbolTable, methodRegistry) {
     methodRegistry.register(
       t.String, 'length', [], t.Int,
-      ({receiver}) => receiver.length)
+      ({receiver}) => receiver.length
+    ).markPure()
 
     methodRegistry.register(
       t.String, 'empty', [], t.Bool,
-      ({receiver}) => receiver.length === 0)
+      ({receiver}) => receiver.length === 0
+    ).markPure()
 
     const substringBody = ({receiver}, start, length) => {
       return receiver.substr(start, length)
@@ -18,13 +20,14 @@ module.exports = {
 
     methodRegistry.register(
       t.String, 'substring', [t.Int, t.Int], t.String,
-      substringBody)
+      substringBody).markPure()
     methodRegistry.register(
       t.String, 'substring', [t.Int], t.String,
-      substringBody)
+      substringBody).markPure()
 
     methodRegistry.register(
       t.String, '+', [t.String], t.String,
-      ({receiver}, operand) => receiver + operand)
+      ({receiver}, operand) => receiver + operand
+    ).markPure()
   }
 }

--- a/src/gnomish/symboltable.js
+++ b/src/gnomish/symboltable.js
@@ -63,7 +63,9 @@ class SymbolTable {
     if (v === undefined) {
       if (this.parent) {
         const inherited = this.parent.binding(name)
-        this.captures.add(inherited.frame)
+        if (!inherited.entry.isStatic()) {
+          this.captures.add(inherited.frame)
+        }
         return inherited
       } else {
         throw new Error(`Identifier "${name}" not found`)

--- a/test/gnomish/analyzer.test.js
+++ b/test/gnomish/analyzer.test.js
@@ -659,6 +659,18 @@ describe('Analyzer', function () {
         assert.isFalse(program.node.getLastExpr().hasStaticValue())
         assert.isTrue(called)
       })
+
+      it("may compute the call's value statically", function () {
+        mr.register(
+          tInt, 'something', [tInt], tInt,
+          (_, arg) => arg + 1
+        ).markPure()
+
+        const program = parse('2.something(3)').analyze(st, mr)
+        const callNode = program.node.getLastExpr()
+        assert.isTrue(callNode.hasStaticValue())
+        assert.strictEqual(callNode.getStaticValue(), 4)
+      })
     })
   })
 })

--- a/test/gnomish/analyzer.test.js
+++ b/test/gnomish/analyzer.test.js
@@ -650,17 +650,14 @@ describe('Analyzer', function () {
 
     describe('CallNode', function () {
       it("invokes the method's static callbacks", function () {
-        let before = false
-        let after = false
+        let called = false
 
         const signature = mr.register(tInt, 'something', [], tInt, () => {})
-        signature.setStaticPreCallback(() => { before = true })
-        signature.setStaticPostCallback(() => { after = true })
+        signature.setStaticCallback(() => { called = true })
 
         const program = parse('1.something()').analyze(st, mr)
         assert.isFalse(program.node.getLastExpr().hasStaticValue())
-        assert.isTrue(before)
-        assert.isTrue(after)
+        assert.isTrue(called)
       })
     })
   })

--- a/test/gnomish/analyzer.test.js
+++ b/test/gnomish/analyzer.test.js
@@ -403,18 +403,15 @@ describe('Analyzer', function () {
         const frame2 = block2.getBody()
         const block3 = frame2.getExprs()[0]
 
-        assert.strictEqual(block1.getCaptures().size, 1)
-        assert.isTrue(block1.getCaptures().has(GLOBAL))
+        assert.strictEqual(block1.getCaptures().size, 0)
 
-        assert.strictEqual(block2.getCaptures().size, 2)
+        assert.strictEqual(block2.getCaptures().size, 1)
         assert.isFalse(block2.getCaptures().has(frame0))
         assert.isTrue(block2.getCaptures().has(frame1))
-        assert.isTrue(block2.getCaptures().has(GLOBAL))
 
-        assert.strictEqual(block3.getCaptures().size, 2)
+        assert.strictEqual(block3.getCaptures().size, 1)
         assert.isFalse(block3.getCaptures().has(frame0))
         assert.isTrue(block3.getCaptures().has(frame1))
-        assert.isTrue(block3.getCaptures().has(GLOBAL))
       })
     })
 
@@ -453,18 +450,15 @@ describe('Analyzer', function () {
         const frame2 = block2.getBody()
         const block3 = frame2.getExprs()[0]
 
-        assert.strictEqual(block1.getCaptures().size, 1)
-        assert.isTrue(block1.getCaptures().has(GLOBAL))
+        assert.strictEqual(block1.getCaptures().size, 0)
 
-        assert.strictEqual(block2.getCaptures().size, 2)
+        assert.strictEqual(block2.getCaptures().size, 1)
         assert.isFalse(block2.getCaptures().has(frame0))
         assert.isTrue(block2.getCaptures().has(frame1))
-        assert.isTrue(block2.getCaptures().has(GLOBAL))
 
-        assert.strictEqual(block3.getCaptures().size, 2)
+        assert.strictEqual(block3.getCaptures().size, 1)
         assert.isFalse(block3.getCaptures().has(frame0))
         assert.isTrue(block3.getCaptures().has(frame1))
-        assert.isTrue(block3.getCaptures().has(GLOBAL))
       })
     })
 
@@ -519,6 +513,155 @@ describe('Analyzer', function () {
       const callNode = root.node.getExprs()[0]
 
       assert.strictEqual(callNode.getCallback(), right)
+    })
+  })
+
+  describe('static value derivation', function () {
+    it('assigns Int literals', function () {
+      const program = parse('1').analyze(st, mr)
+      const intNode = program.node.getLastExpr()
+
+      assert.isTrue(intNode.hasStaticValue())
+      assert.equal(intNode.getStaticValue(), 1)
+    })
+
+    it('assigns Real literals', function () {
+      const program = parse('1.0').analyze(st, mr)
+      const intNode = program.node.getLastExpr()
+
+      assert.isTrue(intNode.hasStaticValue())
+      assert.equal(intNode.getStaticValue(), 1.0)
+    })
+
+    it('assigns String literals', function () {
+      const program = parse('"boo"').analyze(st, mr)
+      const stringNode = program.node.getLastExpr()
+
+      assert.isTrue(stringNode.hasStaticValue())
+      assert.equal(stringNode.getStaticValue(), 'boo')
+    })
+
+    describe('VarNode', function () {
+      it('assigns a static value if the var references a static entry', function () {
+        st.setStatic('box', tInt, 10)
+
+        const program = parse('box').analyze(st, mr)
+        const varNode = program.node.getLastExpr()
+
+        assert.isTrue(varNode.hasStaticValue())
+        assert.equal(varNode.getStaticValue(), 10)
+      })
+
+      it('has no static value if the var references a frame slot', function () {
+        st.allocateSlot('box', tString)
+
+        const program = parse('box').analyze(st, mr)
+        const varNode = program.node.getLastExpr()
+
+        assert.isFalse(varNode.hasStaticValue())
+      })
+    })
+
+    it('never assigns a static value to an ArgNode', function () {
+      const program = parse('{ x: Int | x }').analyze(st, mr)
+
+      const blockNode = program.node.getLastExpr()
+      const argNode = blockNode.getArgs()[0]
+      assert.isFalse(argNode.hasStaticValue())
+    })
+
+    describe('BlockNode', function () {
+      it('assigns a static value if the block captures no variables', function () {
+        mr.register(tInt, '+', [tInt], tInt, () => {})
+
+        const program = parse('{ x: Int | x + 4 }').analyze(st, mr)
+
+        const blockNode = program.node.getLastExpr()
+        assert.isTrue(blockNode.hasStaticValue())
+        const block = blockNode.getStaticValue()
+        assert.lengthOf(block.argNodes, 1)
+        assert.strictEqual(block.argNodes[0], blockNode.getArgs()[0])
+        assert.strictEqual(block.bodyNode, blockNode.getBody())
+      })
+
+      it('does not assign a static value if the block has one or more captures', function () {
+        mr.register(tInt, '+', [tInt], tInt, () => {})
+
+        const program = parse(`
+          let outer = 1
+          { y: Int | y + outer }
+        `).analyze(st, mr)
+
+        const blockNode = program.node.getLastExpr()
+        assert.isFalse(blockNode.hasStaticValue())
+      })
+    })
+
+    describe('IfNode', function () {
+      it('assigns a static value if the condition and body both have static values', function () {
+        const program = parse('if {false} then {3} else {4}').analyze(st, mr)
+
+        const ifNode = program.node.getLastExpr()
+        assert.isTrue(ifNode.hasStaticValue())
+        assert.strictEqual(ifNode.getStaticValue(), 4)
+      })
+
+      it('does not assign a static value if the condition is non-static', function () {
+        st.allocateSlot('cond', tBool)
+
+        const program = parse('if {cond} then {3} else {4}')
+
+        const ifNode = program.node.getLastExpr()
+        assert.isFalse(ifNode.hasStaticValue())
+      })
+
+      it('does not assign a static value if the body is non-static', function () {
+        st.allocateSlot('value', tInt)
+
+        const program = parse('if {true} then {3} else {value}')
+
+        const ifNode = program.node.getLastExpr()
+        assert.isFalse(ifNode.hasStaticValue())
+      })
+    })
+
+    it('never assigns a static value to a WhileNode', function () {
+      const program = parse('while {false} do {4}').analyze(st, mr)
+
+      const whileNode = program.node.getLastExpr()
+      assert.isFalse(whileNode.hasStaticValue())
+    })
+
+    it('never assigns a static value to an AssignNode', function () {
+      st.allocateSlot('x', tInt)
+
+      const program = parse('x = 4').analyze(st, mr)
+
+      const assignNode = program.node.getLastExpr()
+      assert.isFalse(assignNode.hasStaticValue())
+    })
+
+    it('never assigns a static value to a LetNode', function () {
+      const program = parse('let y = 4').analyze(st, mr)
+
+      const letNode = program.node.getLastExpr()
+      assert.isFalse(letNode.hasStaticValue())
+    })
+
+    describe('CallNode', function () {
+      it("invokes the method's static callbacks", function () {
+        let before = false
+        let after = false
+
+        const signature = mr.register(tInt, 'something', [], tInt, () => {})
+        signature.setStaticPreCallback(() => { before = true })
+        signature.setStaticPostCallback(() => { after = true })
+
+        const program = parse('1.something()').analyze(st, mr)
+        assert.isFalse(program.node.getLastExpr().hasStaticValue())
+        assert.isTrue(before)
+        assert.isTrue(after)
+      })
     })
   })
 })

--- a/test/gnomish/interpreter.test.js
+++ b/test/gnomish/interpreter.test.js
@@ -98,7 +98,28 @@ describe('Interpreter', function () {
       assert.strictEqual(result, 40)
     })
 
-    it('passes the current implicit receiver')
+    it('prunes calls that have been completed statically', function () {
+      let staticCall = false
+      let runtimeCall = false
+
+      mr.register(
+        tInt, 'selector', [tInt], tInt,
+        ({receiver}, operand) => {
+          runtimeCall = true
+          return receiver + operand
+        }
+      ).setStaticCallback(
+        ({astNode}) => {
+          staticCall = true
+          astNode.setStaticValue(10)
+        }
+      )
+
+      const program = parse('1.selector(2)').analyze(st, mr)
+      const {result} = program.interpret()
+
+      assert.strictEqual(result, 10)
+    })
   })
 
   describe('if statements', function () {

--- a/test/gnomish/interpreter.test.js
+++ b/test/gnomish/interpreter.test.js
@@ -119,6 +119,8 @@ describe('Interpreter', function () {
       const {result} = program.interpret()
 
       assert.strictEqual(result, 10)
+      assert.isTrue(staticCall)
+      assert.isFalse(runtimeCall)
     })
   })
 

--- a/test/gnomish/literals.test.js
+++ b/test/gnomish/literals.test.js
@@ -13,13 +13,13 @@ describe('Gnomish literals', function () {
   describe('integers', function () {
     it('parses positive integers', function () {
       const root = parse('42')
-      assert.equal(onlyExpr(root.node).value, 42)
+      assert.equal(onlyExpr(root.node).getStaticValue(), 42)
       assert.equal(root.sexp(), '(exprlist (42))')
     })
 
     it('parses negative integers', function () {
       const root = parse('-12')
-      assert.equal(onlyExpr(root.node).value, -12)
+      assert.equal(onlyExpr(root.node).getStaticValue(), -12)
       assert.equal(root.sexp(), '(exprlist (-12))')
     })
   })
@@ -27,19 +27,19 @@ describe('Gnomish literals', function () {
   describe('reals', function () {
     it('parses real numbers', function () {
       const root = parse('123.456')
-      assert.equal(onlyExpr(root.node).value, 123.456)
+      assert.equal(onlyExpr(root.node).getStaticValue(), 123.456)
       assert.equal(root.sexp(), '(exprlist (123.456))')
     })
 
     it('parses real numbers between -1 and 1', function () {
       const root = parse('0.344')
-      assert.equal(onlyExpr(root.node).value, 0.344)
+      assert.equal(onlyExpr(root.node).getStaticValue(), 0.344)
       assert.equal(root.sexp(), '(exprlist (0.344))')
     })
 
     it('parses negative real numbers', function () {
       const root = parse('-5.34')
-      assert.equal(onlyExpr(root.node).value, -5.34)
+      assert.equal(onlyExpr(root.node).getStaticValue(), -5.34)
       assert.equal(root.sexp(), '(exprlist (-5.34))')
     })
   })
@@ -47,13 +47,13 @@ describe('Gnomish literals', function () {
   describe('strings', function () {
     it('parses double-quote delimited strings', function () {
       const root = parse('"hi"')
-      assert.equal(onlyExpr(root.node).value, 'hi')
+      assert.equal(onlyExpr(root.node).getStaticValue(), 'hi')
       assert.equal(root.sexp(), '(exprlist ("hi"))')
     })
 
     it('allows escaped internal quotes', function () {
       const root = parse('"foo \\" bar"')
-      assert.equal(onlyExpr(root.node).value, 'foo " bar')
+      assert.equal(onlyExpr(root.node).getStaticValue(), 'foo " bar')
       assert.equal(root.sexp(), '(exprlist ("foo \\" bar"))')
     })
 


### PR DESCRIPTION
Allow methods to have static side effects that occur during the analysis phase if possible. This will be useful for methods that define methods or types, which can be added to the method registry during compilation and used later in the same AST traversal.