### PR TITLE
Integrate Hubot commands

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1501,6 +1501,12 @@
         "scoped-http-client": "0.11.0"
       }
     },
+    "hubot-harness": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/hubot-harness/-/hubot-harness-1.0.0.tgz",
+      "integrity": "sha512-MkRfYK0ab15e1VQLq3u17YYejvbA0QvM79kuIqk5q39V7f88gnIS26vUbaq743SJHDwLxsa5NNjETbdQHXc86Q==",
+      "dev": true
+    },
     "hubot-test-helper": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/hubot-test-helper/-/hubot-test-helper-1.9.0.tgz",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "hubot-adventure",
   "version": "0.0.1",
   "description": "Chat-programmed, chat-driven interactive fiction engine for your Hubot",
-  "main": "index.js",
+  "main": "src/index.js",
   "directories": {
     "doc": "docs"
   },

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "chai": "4.2.0",
     "chai-as-promised": "7.1.1",
     "cross-env": "7.0.2",
+    "hubot-harness": "1.0.0",
     "hubot-test-helper": "1.9.0",
     "mocha": "8.1.3",
     "pegjs-backtrace": "0.2.0",

--- a/src/errors.js
+++ b/src/errors.js
@@ -1,0 +1,43 @@
+class ErrorBuilder {
+  constructor (message) {
+    this.message = message
+    this.userMessage = message
+    this.data = new Map()
+  }
+
+  withUserMessage (userMessage) {
+    this.userMessage = userMessage
+    return this
+  }
+
+  withData (key, value) {
+    this.data.set(key, value)
+    return this
+  }
+
+  raise () {
+    const e = new Error(this.message)
+    e.userMessage = this.userMessage
+    e.data = this.data
+    throw e
+  }
+}
+
+function error (message) {
+  return new ErrorBuilder(message)
+}
+
+function formatError (error) {
+  if (error.userMessage) {
+    let formatted = error.userMessage
+    for (const [k, v] of (error.data || new Map())) {
+      formatted += `\n${k}: ${v}`
+    }
+    return formatted
+  } else {
+    // Non-error() constructed exception.
+    return `:fire: ${error.toString()}\n\`\`\`\n${error.stack}\n\`\`\`\n`
+  }
+}
+
+module.exports = { error, formatError }

--- a/src/gnomish/stdlib/block.js
+++ b/src/gnomish/stdlib/block.js
@@ -26,6 +26,10 @@ class Block {
   evaluate (interpreter, args) {
     return interpreter.evaluateBlock(this, args)
   }
+
+  toString () {
+    return '[block]'
+  }
 }
 
 module.exports = {

--- a/src/gnomish/stdlib/option.js
+++ b/src/gnomish/stdlib/option.js
@@ -12,6 +12,10 @@ class Some {
   getValue () {
     return this.value
   }
+
+  toString () {
+    return `Some(${this.value})`
+  }
 }
 
 const none = {
@@ -21,6 +25,10 @@ const none = {
 
   getValue () {
     throw new Error('Attempt to unwrap value from None')
+  },
+
+  toString () {
+    return '[none]'
   }
 }
 

--- a/src/gnomish/stdlib/pair.js
+++ b/src/gnomish/stdlib/pair.js
@@ -9,6 +9,10 @@ class Pair {
   getLeft () { return this.left }
 
   getRight () { return this.right }
+
+  toString () {
+    return `pair(${this.left}, ${this.right})`
+  }
 }
 
 module.exports = {

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,126 @@
+// Description:
+//   Commands to interact with Adventure worlds and games.
+//
+// Commands:
+//   hubot adventure create world <name> - Create a new adventure world with the current channel as its control channel
+//   hubot adventure list worlds - Show existing adventure worlds
+//   hubot adventure delete world <name> - Delete an adventure world if it has no active games
+//   hubot adventure force delete world <name> - Delete an adventure world and stop all of its active games
+//   hubot adventure create game <world name> - Begin a game in the named world with the current channel as its play channel
+//   hubot adventure list games - Display active games and their play channels
+//   hubot adventure delete game - Stop the game playing in the current channel
+
+const { Universe } = require('./model')
+const { formatError } = require('./errors')
+
+function worldName (raw) {
+  return raw.replace(/^['"]|['"]$/g, '')
+}
+
+function wrap (handler) {
+  return msg => {
+    try {
+      handler(msg)
+    } catch (e) {
+      msg.send(formatError(e))
+    }
+  }
+}
+
+module.exports = function (robot) {
+  const universe = new Universe()
+
+  robot.respond(/adventure create world\s+(.+)/i, wrap(msg => {
+    const name = worldName(msg.match[1])
+    universe.createWorld(name, msg.envelope.room)
+    msg.send(
+      `The world '${name}' has been created and this is its control channel. ` +
+      'Messages with code blocks (```) in this channel will be interpreted as Gnomish code. ' +
+      'Go forth and create!'
+    )
+  }))
+
+  robot.respond(/adventure list world(?:s)?\s*$/i, wrap(msg => {
+    const entries = universe.listWorlds()
+    if (entries.length === 0) {
+      return msg.send(
+        'Available worlds:\n_None created._\n' +
+        `Use \`${robot.name}: adventure create world <name>\` to create a new world controlled from the ` +
+        'current channel.'
+      )
+    }
+
+    msg.send(`Available worlds:\n${entries.map(e => e.name).join('\n')}`)
+  }))
+
+  robot.respond(/adventure delete world\s*(.+)$/i, wrap(msg => {
+    const name = worldName(msg.match[1])
+    universe.deleteWorld(name, false)
+    msg.send(`The world '${name}' has been deleted.`)
+  }))
+
+  robot.respond(/adventure force delete world\s*(.+)$/i, wrap(msg => {
+    const name = worldName(msg.match[1])
+    universe.deleteWorld(name, true)
+    msg.send(`World '${name}' has been deleted and all of its active games have been stopped.`)
+  }))
+
+  robot.hear(/```\n((?:[^`]|`[^`]|``[^`]|)+)\n```\n/, wrap(msg => {
+    const currentWorld = universe.worldForChannel(msg.envelope.room)
+    if (!currentWorld) {
+      return
+    }
+
+    const { result } = currentWorld.execute(msg.match[1], {
+      say (output) {
+        msg.send(output)
+      }
+    })
+    msg.send('```\n' + result.toString() + '\n```\n')
+  }))
+
+  robot.respond(/adventure create game\s+(.+)/i, wrap(msg => {
+    const name = worldName(msg.match[1])
+    universe.createGame(name, msg.envelope.room)
+    msg.send(
+      `**Welcome to ${name}**\n` +
+      `This is now the play channel for a game in the ${name} world. Any message here beginning with a blockquote ` +
+      'character (`>`) will be interpreted as a command.'
+    )
+  }))
+
+  robot.respond(/adventure list game(?:s)\s*$/i, wrap(msg => {
+    const gameEntries = universe.listGames()
+    if (gameEntries.length === 0) {
+      return msg.send(
+        'Running games:\n' +
+        '_None_\n' +
+        `Run \`${robot.name}: adventure create game <World Name>\` to begin playing a game in this channel.`
+      )
+    }
+
+    let response = 'Running games:'
+    for (const gameEntry of gameEntries) {
+      response += `\n${gameEntry.channel} (${gameEntry.worldEntry.name})`
+    }
+    msg.send(response)
+  }))
+
+  robot.respond(/adventure delete game\s*$/i, wrap(msg => {
+    universe.deleteGame(msg.envelope.room)
+    msg.send('This game has been stopped. Thanks for playing!')
+  }))
+
+  robot.hear(/> ([^]+)/i, wrap(msg => {
+    const currentGame = universe.gameForChannel(msg.envelope.room)
+    if (!currentGame) {
+      return
+    }
+
+    currentGame.executeCommand(msg.match[1], {
+      say (output) {
+        msg.send(output)
+      }
+    })
+  }))
+}

--- a/src/index.js
+++ b/src/index.js
@@ -65,7 +65,7 @@ module.exports = function (robot) {
     msg.send(`World '${name}' has been deleted and all of its active games have been stopped.`)
   }))
 
-  robot.hear(/```\n((?:[^`]|`[^`]|``[^`]|)+)\n```\n/, wrap(msg => {
+  robot.hear(/```\n?((?:[^`]|`[^`]|``[^`]|)+)\n?```/, wrap(msg => {
     const currentWorld = universe.worldForChannel(msg.envelope.room)
     if (!currentWorld) {
       return
@@ -76,7 +76,7 @@ module.exports = function (robot) {
         msg.send(output)
       }
     })
-    msg.send('```\n' + result.toString() + '\n```\n')
+    msg.send('```\n' + result.toString() + '\n```')
   }))
 
   robot.respond(/adventure create game\s+(.+)/i, wrap(msg => {

--- a/src/index.js
+++ b/src/index.js
@@ -83,7 +83,7 @@ module.exports = function (robot) {
     const name = worldName(msg.match[1])
     universe.createGame(name, msg.envelope.room)
     msg.send(
-      `**Welcome to ${name}**\n` +
+      `*Welcome to ${name}*\n` +
       `This is now the play channel for a game in the ${name} world. Any message here beginning with a blockquote ` +
       'character (`>`) will be interpreted as a command.'
     )

--- a/src/model/game.js
+++ b/src/model/game.js
@@ -11,6 +11,10 @@ class Game {
     this.slots = this.world.createGameSlots()
   }
 
+  getWorld () {
+    return this.world
+  }
+
   getSymbolTable () {
     return this.world.getSymbolTable()
   }
@@ -60,6 +64,10 @@ class Game {
     } else {
       return this.world.executeCommand(command, interpreter)
     }
+  }
+
+  toString () {
+    return `Game(${this.channel})`
   }
 }
 

--- a/src/model/index.js
+++ b/src/model/index.js
@@ -1,0 +1,3 @@
+const { Universe } = require('./universe')
+
+module.exports = { Universe }

--- a/src/model/noun.js
+++ b/src/model/noun.js
@@ -19,6 +19,10 @@ class Noun {
     return this.room.deleteCommand(`${verb} ${this.name}`)
   }
 
+  toString () {
+    return `Noun("${this.name}")`
+  }
+
   static registerTypes (t, symbolTable, methodRegistry) {
     t.registerType('Noun')
   }

--- a/src/model/room.js
+++ b/src/model/room.js
@@ -102,6 +102,10 @@ class Room {
     return Array.from(this.nouns.values())
   }
 
+  toString () {
+    return `Room("${this.id}", "${this.name}")`
+  }
+
   clear () {
     this.localCommands.clear()
     this.nouns.clear()

--- a/src/model/room.js
+++ b/src/model/room.js
@@ -70,9 +70,9 @@ class Room {
           .replace(nounsRx, match => match.toUpperCase())
           .replace(/"/g, '\\"')
 
-        lookCommand = this.world.execute(`{ say("**${finalName}**\n\n${finalDescription}") }`, context).result
+        lookCommand = this.world.execute(`{ say("*${finalName}*\n\n${finalDescription}") }`, context).result
       } else {
-        lookCommand = this.world.execute(`{ say("**${finalName}**") }`, context).result
+        lookCommand = this.world.execute(`{ say("*${finalName}*") }`, context).result
       }
 
       return lookCommand.evaluate(interpreter, [])

--- a/src/model/universe.js
+++ b/src/model/universe.js
@@ -15,7 +15,7 @@ class Universe {
         .raise()
     }
 
-    const existing = this.worldForChannel(channel)
+    const existing = this.worldsByChannel.get(channel)
     if (existing) {
       error(`Duplicate channel name: ${channel}`)
         .withUserMessage(

--- a/src/model/universe.js
+++ b/src/model/universe.js
@@ -1,0 +1,116 @@
+const { World } = require('./world')
+const { error } = require('../errors')
+
+class Universe {
+  constructor () {
+    this.worldsByName = new Map()
+    this.worldsByChannel = new Map()
+    this.gamesByChannel = new Map()
+  }
+
+  createWorld (name, channel) {
+    if (this.worldsByName.has(name)) {
+      error(`Duplicate world name: ${name}`)
+        .withUserMessage(`Sorry, a world called '${name}' already exists.`)
+        .raise()
+    }
+
+    const existing = this.worldForChannel(channel)
+    if (existing) {
+      error(`Duplicate channel name: ${channel}`)
+        .withUserMessage(
+          `This channel is already the control channel for the world ${existing.name}. ` +
+          'Please create your world in a new channel or delete this world first.'
+        )
+        .raise()
+    }
+
+    const entry = {
+      world: new World(),
+      name: name,
+      channel: channel
+    }
+
+    this.worldsByName.set(name, entry)
+    this.worldsByChannel.set(channel, entry)
+
+    return entry.world
+  }
+
+  listWorlds () {
+    return Array.from(this.worldsByName.values())
+  }
+
+  deleteWorld (name) {
+    const entry = this.worldsByName.get(name)
+    if (entry) {
+      this.worldsByName.delete(entry.name)
+      this.worldsByChannel.delete(entry.channel)
+    } else {
+      error(`No world named: ${name}`)
+        .withUserMessage(`No world called '${name}' exists.`)
+        .raise()
+    }
+  }
+
+  worldNamed (name) {
+    const entry = this.worldsByName.get(name)
+    return entry ? entry.world : null
+  }
+
+  worldForChannel (channel) {
+    const entry = this.worldsByChannel.get(channel)
+    return entry ? entry.world : null
+  }
+
+  createGame (worldName, channel) {
+    const worldEntry = this.worldsByName.get(worldName)
+    if (!worldEntry) {
+      error(`No world named: ${worldName}`)
+        .withUserMessage(`No world called '${worldName}' exists.`)
+        .raise()
+    }
+
+    const existing = this.gamesByChannel.get(channel)
+    if (existing) {
+      error(`Channel '${channel}' is already a play channel`)
+        .withUserMessage(
+          `This channel is already running a game in the world of ${existing.worldEntry.name}. ` +
+          'Please play in a different channel or stop the existing game first.'
+        )
+        .raise()
+    }
+
+    const entry = {
+      game: worldEntry.world.createGame(channel),
+      worldEntry,
+      channel
+    }
+
+    this.gamesByChannel.set(channel, entry)
+
+    return entry.game
+  }
+
+  listGames () {
+    return Array.from(this.gamesByChannel.values())
+  }
+
+  gameForChannel (channel) {
+    const existing = this.gamesByChannel.get(channel)
+    return existing ? existing.game : null
+  }
+
+  deleteGame (channel) {
+    const entry = this.gamesByChannel.get(channel)
+    if (entry) {
+      this.gamesByChannel.delete(channel)
+    } else {
+      error(`No active game in ${channel}`)
+        .withUserMessage('This channel is not currently playing any games.')
+        .raise()
+    }
+  }
+}
+
+module.exports = { Universe }

--- a/src/model/world.js
+++ b/src/model/world.js
@@ -179,6 +179,10 @@ class World {
     return program.interpret(this.symbolTable.getFrame(), this.prototypeSlots)
   }
 
+  toString () {
+    return '[world]'
+  }
+
   static register (symbolTable, methodRegistry) {
     const t = new TypeRegistry(symbolTable)
     const classes = [this, Room, Noun]

--- a/test/bot-commands.test.js
+++ b/test/bot-commands.test.js
@@ -1,0 +1,191 @@
+/* eslint-env mocha */
+
+const { Harness } = require('hubot-harness')
+
+describe('Hubot commands', function () {
+  let hubot
+
+  beforeEach(function () {
+    hubot = new Harness({ name: 'bot' })
+    hubot.load(__dirname, '../src/index')
+  })
+
+  describe('worlds', function () {
+    it('creates a new world', async function () {
+      hubot.say('bot: adventure create world Avalon')
+      await hubot.waitForResponse(/The world 'Avalon' has been created and this is its control channel./)
+    })
+
+    it('fails to create a new world if one with the same name already exists', async function () {
+      const otherRoom = hubot.createRoom('other-room')
+
+      otherRoom.say('bot: adventure create world Avalon')
+      await otherRoom.waitForResponse(/has been created/)
+
+      hubot.say('bot: adventure create world Avalon')
+      await hubot.waitForResponse("Sorry, a world called 'Avalon' already exists.")
+    })
+
+    it('fails to create a new world if the current channel is already a control channel', async function () {
+      hubot.say('bot: adventure create world Avalon')
+      await hubot.waitForResponse(/has been created/)
+
+      hubot.say('bot: adventure create world Faerun')
+      await hubot.waitForResponse(
+        'This channel is already the control channel for the world Avalon. ' +
+        'Please create your world in a new channel or delete this world first.')
+    })
+
+    it('lists available worlds', async function () {
+      hubot.say('bot: adventure list world')
+      await hubot.waitForResponse(
+        'Available worlds:\n_None created._\n' +
+        'Use `bot: adventure create world <name>` to create a new world controlled from the current channel.'
+      )
+
+      const avalonRoom = hubot.createRoom('avalon-control')
+      avalonRoom.say('bot: adventure create world Avalon')
+      await avalonRoom.waitForResponse(/has been created/)
+
+      const faerunRoom = hubot.createRoom('faerun-room')
+      faerunRoom.say('bot: adventure create world Faerun')
+      await faerunRoom.waitForResponse(/has been created/)
+
+      hubot.say('bot: adventure list world')
+      await hubot.waitForResponse('Available worlds:\nAvalon\nFaerun')
+    })
+
+    it('deletes an existing world', async function () {
+      hubot.say('bot: adventure create world Avalon')
+      await hubot.waitForResponse(/has been created/)
+
+      hubot.say('bot: adventure delete world Avalon')
+      await hubot.waitForResponse("The world 'Avalon' has been deleted.")
+    })
+
+    it('tells you if you attempt to delete a non-existent world', async function () {
+      hubot.say('bot: adventure delete world Atlantis')
+      await hubot.waitForResponse(/No world called 'Atlantis' exists./)
+    })
+  })
+
+  describe('world code execution', function () {
+    let avalon
+
+    beforeEach(async function () {
+      avalon = hubot.createRoom('avalon-control')
+      avalon.say('bot: adventure create world Avalon')
+      await avalon.waitForResponse(/has been created/)
+    })
+
+    it('executes gnomish code in control rooms', async function () {
+      avalon.say('```\n3 + 4\n```\n')
+      await avalon.waitForResponse('```\n7\n```\n')
+    })
+  })
+
+  describe('games', function () {
+    let avalonControl, avalonPlay, faerunControl, faerunPlay
+
+    beforeEach(async function () {
+      avalonControl = hubot.createRoom('avalon-control')
+      avalonControl.say('bot: adventure create world Avalon')
+      await avalonControl.waitForResponse(/has been created/)
+
+      avalonControl.say('```\ndefineRoom("home", "Home")\n```\n')
+      await avalonControl.waitForResponse(/Room\("home", "Home"\)/)
+
+      avalonPlay = hubot.createRoom('avalon-play')
+
+      faerunControl = hubot.createRoom('faerun-control')
+      faerunControl.say('bot: adventure create world Faerun')
+      await faerunControl.waitForResponse(/has been created/)
+
+      faerunControl.say('```\ndefineRoom("neverwinter", "Neverwinter")\n```\n')
+      await faerunControl.waitForResponse(/Room\("neverwinter", "Neverwinter"\)/)
+
+      faerunPlay = hubot.createRoom('faerun-play')
+    })
+
+    it('creates a new game of a named world', async function () {
+      avalonPlay.say('bot: adventure create game Avalon')
+      await avalonPlay.waitForResponse(/Welcome to Avalon/)
+    })
+
+    it('fails to create a new game if the named world does not exist', async function () {
+      avalonPlay.say('bot: adventure create game Atlantis')
+      await avalonPlay.waitForResponse("No world called 'Atlantis' exists.")
+    })
+
+    it('fails to create a new game if the current channel already has one', async function () {
+      avalonPlay.say('bot: adventure create game Avalon')
+      await avalonPlay.waitForResponse(/Welcome to Avalon/)
+
+      avalonPlay.say('bot: adventure create game Faerun')
+      await avalonPlay.waitForResponse(/This channel is already running a game in the world of Avalon/)
+    })
+
+    it('lists running games', async function () {
+      hubot.say('bot: adventure list games')
+      await hubot.waitForResponse(
+        'Running games:\n' +
+        '_None_\n' +
+        'Run `bot: adventure create game <World Name>` to begin playing a game in this channel.'
+      )
+
+      avalonPlay.say('bot: adventure create game Avalon')
+      await avalonPlay.waitForResponse(/Welcome to Avalon/)
+
+      faerunPlay.say('bot: adventure create game Faerun')
+      await faerunPlay.waitForResponse(/Welcome to Faerun/)
+
+      hubot.say('bot: adventure list games')
+      await hubot.waitForResponse(
+        'Running games:\n' +
+        'avalon-play (Avalon)\n' +
+        'faerun-play (Faerun)'
+      )
+    })
+
+    it('stops a running game', async function () {
+      avalonPlay.say('bot: adventure create game Avalon')
+      await avalonPlay.waitForResponse(/Welcome to Avalon/)
+
+      avalonPlay.say('bot: adventure delete game')
+      await avalonPlay.waitForResponse(/game has been stopped/)
+    })
+
+    it('tells you if you attempt to stop a game when there is none', async function () {
+      avalonPlay.say('bot: adventure delete game')
+      await avalonPlay.waitForResponse('This channel is not currently playing any games.')
+    })
+  })
+
+  describe('game commands', function () {
+    let control, play
+
+    beforeEach(async function () {
+      control = hubot.createRoom('avalon-control')
+      control.say('bot: adventure create world Avalon')
+      await control.waitForResponse(/has been created/)
+
+      control.say(
+        '```\n' +
+        'let room = defineRoom("home", "Home")\n' +
+        'room.command("call", "and answer")\n' +
+        'room\n' +
+        '```\n'
+      )
+      await control.waitForResponse(/Room\("home", "Home"\)/)
+
+      play = hubot.createRoom('avalon-play')
+      play.say('bot: adventure create game Avalon')
+      await play.waitForResponse(/Welcome to Avalon/)
+    })
+
+    it('interprets blockquotes in play rooms as commands', async function () {
+      play.say('> call')
+      await play.waitForResponse('and answer')
+    })
+  })
+})

--- a/test/bot-commands.test.js
+++ b/test/bot-commands.test.js
@@ -79,8 +79,8 @@ describe('Hubot commands', function () {
     })
 
     it('executes gnomish code in control rooms', async function () {
-      avalon.say('```\n3 + 4\n```\n')
-      await avalon.waitForResponse('```\n7\n```\n')
+      avalon.say('```3 + 4```')
+      await avalon.waitForResponse('```\n7\n```')
     })
   })
 
@@ -170,11 +170,11 @@ describe('Hubot commands', function () {
       await control.waitForResponse(/has been created/)
 
       control.say(
-        '```\n' +
+        '```' +
         'let room = defineRoom("home", "Home")\n' +
         'room.command("call", "and answer")\n' +
-        'room\n' +
-        '```\n'
+        'room' +
+        '```'
       )
       await control.waitForResponse(/Room\("home", "Home"\)/)
 

--- a/test/errors.test.js
+++ b/test/errors.test.js
@@ -1,0 +1,84 @@
+/* eslint-env mocha */
+
+const { assert } = require('chai')
+
+const { error, formatError } = require('../src/errors')
+
+describe('errors', function () {
+  describe('error construction', function () {
+    it('constructs and raises a Error', function () {
+      assert.throws(() => error('message').raise(), 'message')
+    })
+
+    it('may provide a separate user-visible message', function () {
+      let caught = false
+
+      try {
+        error('developer message').withUserMessage('user message').raise()
+      } catch (e) {
+        assert.strictEqual(e.message, 'developer message')
+        assert.strictEqual(e.userMessage, 'user message')
+        caught = true
+      }
+
+      assert.isTrue(caught)
+    })
+
+    it('appends helpful user data', function () {
+      let caught = false
+
+      try {
+        error('message').withData('k0', 'v0').withData('k1', 'v1').raise()
+      } catch (e) {
+        assert.strictEqual(e.message, 'message')
+        assert.strictEqual(e.data.get('k0'), 'v0')
+        assert.strictEqual(e.data.get('k1'), 'v1')
+        caught = true
+      }
+
+      assert.isTrue(caught)
+    })
+  })
+
+  describe('error report formatting', function () {
+    it('also formats ordinary errors', function () {
+      let formatted = ''
+      try {
+        throw new Error('message')
+      } catch (e) {
+        formatted = formatError(e)
+      }
+
+      assert.include(formatted, 'Error: message')
+      assert.include(formatted, 'errors.test.js')
+    })
+
+    it('uses the user-visible messaging', function () {
+      let formatted = ''
+      try {
+        error('dev message').withUserMessage('user message').raise()
+      } catch (e) {
+        formatted = formatError(e)
+      }
+
+      assert.include(formatted, 'user message')
+      assert.notInclude(formatted, 'dev message')
+      assert.notInclude(formatted, 'errors.test.js')
+    })
+
+    it('includes any provided user data', function () {
+      let formatted = ''
+      try {
+        error('dev message')
+          .withData('k0', 'v0')
+          .withData('k1', 'v1')
+          .raise()
+      } catch (e) {
+        formatted = formatError(e)
+      }
+
+      assert.include(formatted, 'k0: v0')
+      assert.include(formatted, 'k1: v1')
+    })
+  })
+})

--- a/test/model/room.test.js
+++ b/test/model/room.test.js
@@ -122,7 +122,7 @@ describe('Room', function () {
       const i = new Interpreter({ say (line) { said.push(line) } })
 
       r.executeCommand('look', i)
-      assert.deepEqual(said, ['**Name**'])
+      assert.deepEqual(said, ['*Name*'])
     })
 
     it('is used in the output of the generated "look" command', function () {
@@ -132,7 +132,7 @@ describe('Room', function () {
       const i = new Interpreter({ say (line) { said.push(line) } })
 
       r.executeCommand('look', i)
-      assert.deepEqual(said, ['**Name**\n\nContains some stuff.'])
+      assert.deepEqual(said, ['*Name*\n\nContains some stuff.'])
     })
 
     it('automatically puts nouns in all caps', function () {
@@ -143,7 +143,7 @@ describe('Room', function () {
       const i = new Interpreter({ say (line) { said.push(line) } })
 
       r.executeCommand('look', i)
-      assert.deepEqual(said, ['**Name**\n\nContains some STUFF.'])
+      assert.deepEqual(said, ['*Name*\n\nContains some STUFF.'])
     })
   })
 })

--- a/test/model/universe.test.js
+++ b/test/model/universe.test.js
@@ -1,0 +1,105 @@
+/* eslint-env mocha */
+
+const { assert } = require('chai')
+const { Universe } = require('../../src/model/universe')
+
+describe.only('Universe', function () {
+  let universe
+
+  beforeEach(function () {
+    universe = new Universe()
+  })
+
+  describe('worlds', function () {
+    it('creates a new world', function () {
+      assert.lengthOf(universe.listWorlds(), 0)
+      const world = universe.createWorld('name', 'channel')
+
+      assert.lengthOf(universe.listWorlds(), 1)
+      assert.strictEqual(world, universe.worldNamed('name'))
+      assert.strictEqual(world, universe.worldForChannel('channel'))
+    })
+
+    it('fails to create a new world with a duplicate name', function () {
+      universe.createWorld('existing', 'channel0')
+
+      assert.throws(() => universe.createWorld('existing', 'channel1'), /Duplicate world name/)
+    })
+
+    it('fails to create a new world with a duplicate channel', function () {
+      universe.createWorld('name0', 'channel')
+
+      assert.throws(() => universe.createWorld('name1', 'channel'), /Duplicate channel name/)
+    })
+
+    it('lists existing worlds', function () {
+      const worlds = [
+        universe.createWorld('zero', 'channel0'),
+        universe.createWorld('one', 'channel1'),
+        universe.createWorld('two', 'channel2')
+      ]
+
+      assert.deepEqual(universe.listWorlds().map(e => e.world), worlds)
+    })
+
+    it('deletes an existing world', function () {
+      const w0 = universe.createWorld('existing0', 'channel0')
+      universe.createWorld('existing1', 'channel1')
+      const w2 = universe.createWorld('existing2', 'channel2')
+
+      universe.deleteWorld('existing1')
+
+      assert.deepEqual(universe.listWorlds().map(e => e.world), [w0, w2])
+    })
+
+    it('fails to delete a world that does not exist', function () {
+      assert.throws(() => universe.deleteWorld('no'), /No world named/)
+    })
+  })
+
+  describe('games', function () {
+    beforeEach(function () {
+      universe.createWorld('the-world', 'control-channel')
+      universe.createWorld('other-world', 'other-control-channel')
+    })
+
+    it('creates a new game', function () {
+      assert.lengthOf(universe.listGames(), 0)
+      const game = universe.createGame('the-world', 'play-channel')
+
+      assert.lengthOf(universe.listGames(), 1)
+      assert.strictEqual(universe.gameForChannel('play-channel'), game)
+    })
+
+    it('fails to create a new game for an unrecognized world', function () {
+      assert.throws(() => universe.createGame('unknown-world', 'play-channel'), /No world named/)
+    })
+
+    it('fails to create a new game with a duplicate play channel', function () {
+      universe.createGame('other-world', 'same-play-channel')
+
+      assert.throws(() => universe.createGame('the-world', 'same-play-channel'), /already a play channel/)
+    })
+
+    it('lists existing games by channel', function () {
+      const g0 = universe.createGame('the-world', 'play-channel-0')
+      const g1 = universe.createGame('the-world', 'play-channel-1')
+      const g2 = universe.createGame('other-world', 'play-channel-2')
+
+      assert.deepEqual(universe.listGames().map(e => e.game), [g0, g1, g2])
+      assert.deepEqual(universe.listGames().map(e => e.channel), ['play-channel-0', 'play-channel-1', 'play-channel-2'])
+    })
+
+    it('deletes an existing game', function () {
+      universe.createGame('the-world', 'play-channel')
+
+      universe.deleteGame('play-channel')
+
+      assert.isNull(universe.gameForChannel('play-channel'))
+    })
+
+    it('fails to delete a game when none is playing', function () {
+      assert.throws(() => universe.deleteGame('nothing-here'), /No active game/)
+    })
+  })
+})

--- a/test/model/universe.test.js
+++ b/test/model/universe.test.js
@@ -47,13 +47,13 @@ describe.only('Universe', function () {
       universe.createWorld('existing1', 'channel1')
       const w2 = universe.createWorld('existing2', 'channel2')
 
-      universe.deleteWorld('existing1')
+      universe.deleteWorld('existing1', false)
 
       assert.deepEqual(universe.listWorlds().map(e => e.world), [w0, w2])
     })
 
     it('fails to delete a world that does not exist', function () {
-      assert.throws(() => universe.deleteWorld('no'), /No world named/)
+      assert.throws(() => universe.deleteWorld('no', false), /No world named/)
     })
   })
 
@@ -93,13 +93,36 @@ describe.only('Universe', function () {
     it('deletes an existing game', function () {
       universe.createGame('the-world', 'play-channel')
 
-      universe.deleteGame('play-channel')
+      universe.deleteGame('play-channel', false)
 
       assert.isNull(universe.gameForChannel('play-channel'))
     })
 
     it('fails to delete a game when none is playing', function () {
-      assert.throws(() => universe.deleteGame('nothing-here'), /No active game/)
+      assert.throws(() => universe.deleteGame('nothing-here', false), /No active game/)
+    })
+
+    it('fails to delete a world with active games', function () {
+      universe.createWorld('new-world', 'new-world-control-channel')
+      universe.createGame('new-world', 'new-world-play-channel')
+
+      assert.throws(() => universe.deleteWorld('new-world', false), /active games/)
+    })
+
+    it('deletes a world and its active games if forced', function () {
+      universe.createWorld('new-world', 'new-world-control-channel')
+
+      const g0 = universe.createGame('the-world', 'play-channel-0')
+      const g = universe.createGame('new-world', 'new-world-play-channel')
+      const g1 = universe.createGame('other-world', 'play-channel-1')
+
+      assert.deepEqual(universe.listWorlds().map(e => e.name), ['the-world', 'other-world', 'new-world'])
+      assert.deepEqual(universe.listGames().map(e => e.game), [g0, g, g1])
+
+      universe.deleteWorld('new-world', true)
+
+      assert.deepEqual(universe.listWorlds().map(e => e.name), ['the-world', 'other-world'])
+      assert.deepEqual(universe.listGames().map(e => e.game), [g0, g1])
     })
   })
 })

--- a/test/model/universe.test.js
+++ b/test/model/universe.test.js
@@ -3,7 +3,7 @@
 const { assert } = require('chai')
 const { Universe } = require('../../src/model/universe')
 
-describe.only('Universe', function () {
+describe('Universe', function () {
   let universe
 
   beforeEach(function () {


### PR DESCRIPTION
Create a Hubot script entrypoint to the package. Wire it up to a Universe model that manages Worlds and Games. Implement `hubot: adventure`-prefixed commands to create, list, and delete Worlds and Games, run gnomish code in World control channels, and accept commands in Game play channels.